### PR TITLE
Remove usage of package module

### DIFF
--- a/roles/opencas-install/tasks/main.yml
+++ b/roles/opencas-install/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-- name: Get dependencies
-  block:
-    - package:
-        name: git
-        state: present
-    - package:
-        name: make
-        state: present
-  become: True
-
 - name: Check if installation may proceed
   fail:
     msg: |


### PR DESCRIPTION
Unfortunately package module still uses Python2 on some OSes. Because of
that it conflicts with purely Python3 CAS utility modules.

Signed-off-by: Jan Musial <jan.musial@intel.com>